### PR TITLE
remove ‘inspect’ fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,15 +56,10 @@
 
   Useless['@@type'] = 'sanctuary-useless/Useless@1';
 
-  function inspect() {
-    return 'Useless';
-  }
-  var custom = util.inspect.custom;
+  var custom = util.inspect.custom;  // added in Node.js v6.6.0
   /* istanbul ignore else */
   if (typeof custom === 'symbol') {
-    Useless[custom] = inspect;
-  } else {
-    Useless.inspect = inspect;
+    Useless[custom] = function() { return 'Useless'; };
   }
 
   return Useless;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "/index.js",
     "/package.json"
   ],
+  "engines": {
+    "node": ">=6.6.0"
+  },
   "dependencies": {},
   "devDependencies": {
     "sanctuary-scripts": "4.0.x",


### PR DESCRIPTION
According to <https://nodejs.org/en/download/releases/>, v6.6.0 was released on 2016-09-14. The fallback for older versions of Node.js is no longer warranted.
