### PR TITLE
use global symbol to customize string representations in Node.js REPL

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
     },
     {
       "files": ["index.js"],
-      "globals": {"Deno": false}
+      "globals": {"Deno": false, "process": false}
     }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -37,18 +37,16 @@
 
   'use strict';
 
-  const util = {inspect: {}};
-
   /* istanbul ignore else */
   if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = f (require ('util'));
+    module.exports = f ();
   } else if (typeof define === 'function' && define.amd != null) {
-    define ([], () => f (util));
+    define ([], f);
   } else {
-    self.sanctuaryUseless = f (util);
+    self.sanctuaryUseless = f ();
   }
 
-}) (util => {
+}) (() => {
 
   'use strict';
 
@@ -56,15 +54,21 @@
 
   Useless['@@type'] = 'sanctuary-useless/Useless@1';
 
-  {
-    const {custom} = util.inspect;  // added in Node.js v6.6.0
-    /* istanbul ignore else */
-    if (typeof custom === 'symbol') Useless[custom] = () => 'Useless';
-    /* istanbul ignore if */
-    if (typeof Deno !== 'undefined') {
-      if (Deno != null && typeof Deno.customInspect === 'symbol') {
-        Useless[Deno.customInspect] = () => 'Useless';
-      }
+  /* istanbul ignore else */
+  if (
+    typeof process !== 'undefined' &&
+    process != null &&
+    process.versions != null &&
+    process.versions.node != null
+  ) {
+    Useless[
+      Symbol.for ('nodejs.util.inspect.custom')  // added in Node.js v10.12.0
+    ] = () => 'Useless';
+  }
+  /* istanbul ignore if */
+  if (typeof Deno !== 'undefined') {
+    if (Deno != null && typeof Deno.customInspect === 'symbol') {
+      Useless[Deno.customInspect] = () => 'Useless';
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "/package.json"
   ],
   "engines": {
-    "node": ">=6.6.0"
+    "node": ">=10.12.0"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Relates to sanctuary-js/sanctuary#718

<https://nodejs.org/en/blog/release/v10.12.0/>

/cc @majkelch
