### PR TITLE
use ES modules

### DIFF
--- a/.config
+++ b/.config
@@ -1,4 +1,3 @@
 repo-owner = sanctuary-js
 repo-name = sanctuary-useless
 contributing-file = .github/CONTRIBUTING.md
-module-type = commonjs

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,15 @@
 {
   "root": true,
   "extends": ["./node_modules/sanctuary-style/eslint.json"],
+  "parserOptions": {"sourceType": "module"},
   "overrides": [
     {
       "files": ["index.js"],
-      "globals": {"Deno": "readonly", "define": "readonly", "module": "readonly", "process": "readonly", "self": "readonly"}
+      "globals": {"Deno": "readonly", "process": "readonly"}
     },
     {
       "files": ["test/**/*.js"],
-      "parserOptions": {"ecmaVersion": 2020, "sourceType": "module"}
+      "parserOptions": {"ecmaVersion": 2020}
     }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -4,78 +4,67 @@
 //. sanctuary-useless/Useless type:
 //.
 //. ```javascript
-//. //    Useless :: Useless
-//. const Useless = require ('sanctuary-useless');
+//. import {Useless} from 'sanctuary-useless';
 //. ```
 //.
 //. `Useless`, as its name suggests, has no functionality. This makes it useful
 //. for testing algebraic data types which satisfy various [type classes][].
 //.
-//. The following assertion, in isolation, suggests that `Identity a` satisfies
+//. ```javascript
+//. > import Identity from 'sanctuary-identity'
+//. > import Z from 'sanctuary-type-classes'
+//. ```
+//.
+//. The following behaviour, in isolation, suggests that `Identity a` satisfies
 //. [`Z.Setoid`][] _for all_ `a`:
 //.
 //. ```javascript
-//. eq (Z.Setoid.test (Identity (0))) (true);
+//. > Z.Setoid.test (Identity (0))
+//. true
 //. ```
 //.
 //. `Identity Useless`, though, does not satisfy `Z.Setoid`, indicating that
 //. `a` is constrained in some way:
 //.
 //. ```javascript
-//. eq (Z.Setoid.test (Identity (Useless))) (false);
-//. eq (Z.Setoid.test (Identity (0))) (true);
+//. > Z.Setoid.test (Identity (Useless))
+//. false
+//.
+//. > Z.Setoid.test (Identity (0))
+//. true
 //. ```
 //.
 //. Conversely, one can use `Useless` to demonstrate universal quantification
 //. where applicable:
 //.
 //. ```javascript
-//. eq (Z.Functor.test (Identity (Useless))) (true);
+//. > Z.Functor.test (Identity (Useless))
+//. true
 //. ```
 
-(f => {
+export {Useless};
 
-  'use strict';
+const Useless = {};
 
-  /* c8 ignore start */
-  if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = f ();
-  } else if (typeof define === 'function' && define.amd != null) {
-    define ([], f);
-  } else {
-    self.sanctuaryUseless = f ();
-  }
-  /* c8 ignore stop */
+Useless['@@type'] = 'sanctuary-useless/Useless@1';
 
-}) (() => {
+if (
+  typeof process !== 'undefined' &&
+  process != null &&
+  process.versions != null &&
+  process.versions.node != null
+) {
+  const inspect = Symbol.for ('nodejs.util.inspect.custom');
+  Useless[inspect] = () => 'Useless';
+}
 
-  'use strict';
-
-  const Useless = {};
-
-  Useless['@@type'] = 'sanctuary-useless/Useless@1';
-
-  if (
-    typeof process !== 'undefined' &&
-    process != null &&
-    process.versions != null &&
-    process.versions.node != null
-  ) {
-    const inspect = Symbol.for ('nodejs.util.inspect.custom');
-    Useless[inspect] = () => 'Useless';
-  }
-
-  /* c8 ignore start */
-  if (
-    typeof Deno !== 'undefined' &&
-    Deno != null &&
-    typeof Deno.customInspect === 'symbol'
-  ) Useless[Deno.customInspect] = () => 'Useless';
-  /* c8 ignore stop */
-
-  return Useless;
-
-});
+/* c8 ignore start */
+if (
+  typeof Deno !== 'undefined' &&
+  Deno != null &&
+  typeof Deno.customInspect === 'symbol'
+) Useless[Deno.customInspect] = () => 'Useless';
+/* c8 ignore stop */
 
 //. [`Z.Setoid`]:       v:sanctuary-js/sanctuary-type-classes#Setoid
 //. [type classes]:     v:sanctuary-js/sanctuary-type-classes

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "type": "git",
     "url": "git://github.com/sanctuary-js/sanctuary-useless.git"
   },
+  "type": "module",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
   "files": [
     "/LICENSE",
     "/README.md",
@@ -14,10 +19,11 @@
     "/package.json"
   ],
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=16.0.0"
   },
   "dependencies": {},
   "devDependencies": {
+    "sanctuary-identity": "2.1.x",
     "sanctuary-scripts": "7.0.x",
     "sanctuary-type-classes": "13.0.0",
     "sanctuary-type-identifiers": "4.0.x"

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ import test from 'oletus';
 import Z from 'sanctuary-type-classes';
 import type from 'sanctuary-type-identifiers';
 
-import Useless from '../index.js';
+import {Useless} from '../index.js';
 
 
 test ('Useless', () => {

--- a/test/package.json
+++ b/test/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}


### PR DESCRIPTION
sanctuary-js/sanctuary#726

This is the most significant line of the pull request:

```javascript
export {Useless};
```

I used a named export rather than a default export to make this package, which exports one data constructor, consistent with packages that export multiple data constructors. In other words, the export is named `Useless` rather than `default`.
